### PR TITLE
Package the contents of src/contrib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,23 @@
                     <rerunFailingTestsCount>4</rerunFailingTestsCount>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/contrib</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>            
         </plugins>
     </build>
 


### PR DESCRIPTION
I'm trying to get org.apache.commons.httpclient.contrib.ssl.EasySSLProtocolSocketFactory from this library, as suggested by @MarkEWaite in https://issues.jenkins-ci.org/browse/JENKINS-55153
It's copy has been removed from upcoming git plugin 4.0/git-client plugin 3.0.

