### PR TITLE
[JENKINS-63269] - Exclude JUnit and Hamcrest from the dependency list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>


### PR DESCRIPTION
While working on Jenkinsfile Runner, I have noticed that the Jenkins Core includes JUnit JAR and Hamcrest JARs as transitive dependencies.  Looks like it was my mistake in 2017 when I was working on a custom patch for `commons-httpclient` with vulnerability fix backports. It leads to 350KB of extra libraries, and, which is worse, potentially messes up the classpaths for testing environments and plugins.

https://issues.jenkins-ci.org/browse/JENKINS-63269

Dependency tree:

```
[INFO] +- io.jenkins.jenkinsfile-runner:setup:jar:1.0-beta-16-SNAPSHOT:compile
[INFO] |  +- org.jenkins-ci.main:jenkins-core:jar:2.246:compile
....
[INFO] |  |  +- org.kohsuke.stapler:json-lib:jar:2.4-jenkins-2:compile
[INFO] |  |  |  \- net.sf.ezmorph:ezmorph:jar:1.0.6:compile
[INFO] |  |  +- commons-httpclient:commons-httpclient:jar:3.1-jenkins-1:compile
[INFO] |  |  |  \- junit:junit:jar:4.13:compile
[INFO] |  |  |     \- org.hamcrest:hamcrest-core:jar:1.3:compile
```

Screenshot of a jenkins.war:

![image](https://user-images.githubusercontent.com/3000480/89108525-76d33900-d439-11ea-9207-4087377977c6.png)

![image](https://user-images.githubusercontent.com/3000480/89108539-9c604280-d439-11ea-804f-2e280fb2ed8d.png)
